### PR TITLE
Fix slime ball recipe

### DIFF
--- a/src/main/resources/data/create/recipes/crafting/appliances/slime_ball.json
+++ b/src/main/resources/data/create/recipes/crafting/appliances/slime_ball.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
     {
-      "tag": "c:dough"
+      "tag": "c:wheat_dough"
     },
     {
       "tag": "c:lime_dyes"


### PR DESCRIPTION
This recipe was broken, but a simple tag change not only fixes it but also adds support for using the Farmer's Delight wheat dough in place of Create's dough.

<img width="313" alt="image" src="https://github.com/PssbleTrngle/SliceAndDice-Fabric/assets/6100522/1eb09c2e-db9e-4ed7-beb9-dabf10a40d20">